### PR TITLE
fix out on a limb auto continue when lang is FR

### DIFF
--- a/Saucy/OutOnALimb/LimbManager.cs
+++ b/Saucy/OutOnALimb/LimbManager.cs
@@ -71,13 +71,16 @@ public unsafe class LimbManager : IDisposable
             EzThrottler.Throttle("InteractPause", 1000, true);
         }
         if (!EzThrottler.Check("InteractPause")) return;
+
+        //2005423	Out on a Limb	0	Out on a Limb machines	0	1	1	0	0
+        var machineNameGS = Svc.Data.GetExcelSheet<EObjName>().GetRow(2005423).Singular.GetText().RemoveSpaces();
+        //30425	Out on a Limb machine	0	Out on a Limb machines	0	1	1	0	0	Experience the heart-exploding excitement of the Gold Saucer in your own home with this authentic Out on a Limb machine.	Out on a Limb Machine	ui/icon/052000/052680.tex	1	1	14	Out on a Limb Machine	Furnishing		EquipSlotCategory#0	125	18740	1	False	True	False	False	2	0	False	False	False	ItemAction#0	2	0	adventurer	ItemRepairResource#0		0	False	False	0	1	0	0		None		0	0, 0, 0, 0	0, 0, 0, 0	adventurer	0	0	0	0	0	0	0	0	0		0		0		0		0		0		0		0		0		0		0		0		0		0	0	0	False	False	0	False
+        var machineNameHousing = Svc.Data.GetExcelSheet<Item>().GetRow(30425).Singular.GetText().RemoveSpaces();
+
         var found = false;
         foreach (var x in Svc.Objects)
         {
-            //2005423	Out on a Limb	0	Out on a Limb machines	0	1	1	0	0
-            //30425	Out on a Limb machine	0	Out on a Limb machines	0	1	1	0	0	Experience the heart-exploding excitement of the Gold Saucer in your own home with this authentic Out on a Limb machine.	Out on a Limb Machine	ui/icon/052000/052680.tex	1	1	14	Out on a Limb Machine	Furnishing		EquipSlotCategory#0	125	18740	1	False	True	False	False	2	0	False	False	False	ItemAction#0	2	0	adventurer	ItemRepairResource#0		0	False	False	0	1	0	0		None		0	0, 0, 0, 0	0, 0, 0, 0	adventurer	0	0	0	0	0	0	0	0	0		0		0		0		0		0		0		0		0		0		0		0		0		0	0	0	False	False	0	False
-
-            if (x.Name.GetText().EqualsIgnoreCaseAny(Svc.Data.GetExcelSheet<EObjName>().GetRow(2005423).Singular.GetText(), Svc.Data.GetExcelSheet<Item>().GetRow(30425).Singular.GetText()) && x.ObjectKind.EqualsAny(ObjectKind.EventObj, ObjectKind.Housing) && Vector3.Distance(Player.Object.Position, x.Position) < 4)
+            if (x.ObjectKind.EqualsAny(ObjectKind.EventObj, ObjectKind.Housing) && x.Name.GetText().RemoveSpaces().EqualsIgnoreCaseAny(machineNameGS, machineNameHousing) && Vector3.Distance(Player.Object.Position, x.Position) < 4)
             {
                 found = true;
                 if (EzThrottler.Throttle("TargetAndInteract"))

--- a/Saucy/OutOnALimb/LimbManager.cs
+++ b/Saucy/OutOnALimb/LimbManager.cs
@@ -70,13 +70,16 @@ public unsafe class LimbManager : IDisposable
             EzThrottler.Throttle("InteractPause", 1000, true);
         }
         if (!EzThrottler.Check("InteractPause")) return;
+
+        //2005423	Out on a Limb	0	Out on a Limb machines	0	1	1	0	0
+        var machineNameGS = Svc.Data.GetExcelSheet<EObjName>().GetRow(2005423).Singular.GetText().RemoveSpaces();
+        //30425	Out on a Limb machine	0	Out on a Limb machines	0	1	1	0	0	Experience the heart-exploding excitement of the Gold Saucer in your own home with this authentic Out on a Limb machine.	Out on a Limb Machine	ui/icon/052000/052680.tex	1	1	14	Out on a Limb Machine	Furnishing		EquipSlotCategory#0	125	18740	1	False	True	False	False	2	0	False	False	False	ItemAction#0	2	0	adventurer	ItemRepairResource#0		0	False	False	0	1	0	0		None		0	0, 0, 0, 0	0, 0, 0, 0	adventurer	0	0	0	0	0	0	0	0	0		0		0		0		0		0		0		0		0		0		0		0		0		0	0	0	False	False	0	False
+        var machineNameHousing = Svc.Data.GetExcelSheet<Item>().GetRow(30425).Singular.GetText().RemoveSpaces();
+
         var found = false;
         foreach (var x in Svc.Objects)
         {
-            //2005423	Out on a Limb	0	Out on a Limb machines	0	1	1	0	0
-            //30425	Out on a Limb machine	0	Out on a Limb machines	0	1	1	0	0	Experience the heart-exploding excitement of the Gold Saucer in your own home with this authentic Out on a Limb machine.	Out on a Limb Machine	ui/icon/052000/052680.tex	1	1	14	Out on a Limb Machine	Furnishing		EquipSlotCategory#0	125	18740	1	False	True	False	False	2	0	False	False	False	ItemAction#0	2	0	adventurer	ItemRepairResource#0		0	False	False	0	1	0	0		None		0	0, 0, 0, 0	0, 0, 0, 0	adventurer	0	0	0	0	0	0	0	0	0		0		0		0		0		0		0		0		0		0		0		0		0		0	0	0	False	False	0	False
-
-            if (x.Name.GetText().EqualsIgnoreCaseAny(Svc.Data.GetExcelSheet<EObjName>().GetRow(2005423).Singular.GetText(), Svc.Data.GetExcelSheet<Item>().GetRow(30425).Singular.GetText()) && x.ObjectKind.EqualsAny(ObjectKind.EventObj, ObjectKind.HousingEventObject) && Vector3.Distance(Player.Object.Position, x.Position) < 4)
+            if (x.ObjectKind.EqualsAny(ObjectKind.EventObj, ObjectKind.HousingEventObject) && x.Name.GetText().RemoveSpaces().EqualsIgnoreCaseAny(machineNameGS, machineNameHousing) && Vector3.Distance(Player.Object.Position, x.Position) < 4)
             {
                 found = true;
                 if (EzThrottler.Throttle("TargetAndInteract"))


### PR DESCRIPTION
Hey, 

While it works fine directly in the gold saucer, it seems using the plugin on the Out on a Limb machine in a house does not auto continue while the game language is set to french. After testing/debugging it seems to work fine on all other languages, and it's due to a missing space of the object name in the room compared to the name in the datasheet that is used.

In PluginUI.cs
```csharp
    private void DrawDebugTab()
    {
        if (!Player.Available) return;
        if (!IsScreenReady()) return;

        ImGui.TextUnformatted($"EObjName<2005423>: '{Svc.Data.GetExcelSheet<EObjName>().GetRow(2005423).Singular.GetText()}'");
        ImGui.TextUnformatted($"Item<30425>: '{Svc.Data.GetExcelSheet<Item>().GetRow(30425).Singular.GetText()}'");
        ImGui.Separator();
        int i = 0;
        foreach (var x in Svc.Objects)
        {
            if(x.ObjectKind != ObjectKind.Housing) continue;
            var distance = Vector3.Distance(Player.Object.Position, x.Position);
            ImGui.TextUnformatted($"#{i}");
            ImGui.TextUnformatted($"Item: '{x.Name}'");
            ImGui.TextUnformatted($"ObjectKind: {x.ObjectKind}");
            ImGui.TextUnformatted($"distance: {distance}");
            i++;
        }
    }
```

That shows the missing space:
<img width="822" height="389" alt="image" src="https://github.com/user-attachments/assets/534adebf-f9c1-4d94-9381-6fbf946426d8" />

So the fix proposed is to remove the spaces when comparing texts, maybe there's a more optimized way of doing it? (like using another item id / attribute in those data sheets for example idk)